### PR TITLE
Add vendor info to zipcode lookup type

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -18,10 +18,30 @@ export interface RecentAgenda {
     packet_url?: string;
 }
 
+/**
+ * Information returned when looking up a zipcode.
+ * Includes vendor metadata and any cached meetings for the city.
+ */
+export interface ZipcodeLookupResult {
+    zipcode: string;
+    city: string;
+    city_slug: string;
+    state: string;
+    county: string;
+    vendor: string;
+    meetings: Meeting[];
+}
+
 const API_BASE_URL = 'http://165.232.158.241:8000';
 
 export class ApiService {
-    static async lookupZipcode(zipcode: string): Promise<{zipcode: string, city: string, city_slug: string, state: string, county: string}> {
+    /**
+     * Resolve a zipcode to city information.
+     *
+     * The API response also provides the packet vendor for the city and any
+     * cached meetings that were discovered during the lookup.
+     */
+    static async lookupZipcode(zipcode: string): Promise<ZipcodeLookupResult> {
         try {
             console.log(`Fetching: ${API_BASE_URL}/api/zipcode-lookup/${zipcode}`);
             const response = await fetch(`${API_BASE_URL}/api/zipcode-lookup/${zipcode}`, {
@@ -63,7 +83,7 @@ export class ApiService {
         }
     }
 
-    static async searchMeetings(searchInput: string): Promise<{meetings: Meeting[], city: string, city_slug: string, zipcode: string}> {
+    static async searchMeetings(searchInput: string): Promise<{meetings: Meeting[], city: string, city_slug: string, zipcode: string, vendor: string}> {
         const normalized = searchInput.trim();
         
         // Only accept zipcode input (5 digits)
@@ -79,7 +99,8 @@ export class ApiService {
                 meetings,
                 city: zipcodeResult.city,
                 city_slug: zipcodeResult.city_slug,
-                zipcode: zipcodeResult.zipcode
+                zipcode: zipcodeResult.zipcode,
+                vendor: zipcodeResult.vendor
             };
         } catch (error) {
             throw new Error(`No meetings found for "${normalized}", error is "${error}".`);


### PR DESCRIPTION
## Summary
- add a `ZipcodeLookupResult` interface describing the API response
- include vendor and meetings fields when looking up a zipcode
- expose vendor in `searchMeetings` response
- document zipcode lookup API in a JSDoc block

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6846dcdd62ec8331a7230a3f7bbfde30