### PR TITLE
Add root endpoint check in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -153,6 +153,11 @@ test_api() {
     
     # Test root endpoint
 
+    if curl -s "http://localhost:8000/" | grep -q "engagic API"; then
+        log "✓ Root endpoint responding"
+    else
+        warn "⚠ Root endpoint may have issues"
+    fi
     
     # Test meetings endpoint
     if curl -s "http://localhost:8000/api/meetings" | grep -q "packet_url\|error"; then


### PR DESCRIPTION
## Summary
- expand `test_api` in `deploy.sh` to check the root endpoint

## Testing
- `bash -n deploy.sh`

------
https://chatgpt.com/codex/tasks/task_e_6846dcde30748331bd2d6dd7c6df5aef